### PR TITLE
Add GitPython version 3.1.29 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ urllib3==1.26.9
 Werkzeug==2.1.2
 whitenoise==6.2.0
 zipp==3.8.0
+GitPython==3.1.29


### PR DESCRIPTION
Testing Github Action for Dependency review. 